### PR TITLE
Auto-generate random colors for new processes

### DIFF
--- a/components/ProcessForm.tsx
+++ b/components/ProcessForm.tsx
@@ -16,6 +16,14 @@ import { Input } from "@/components/ui/input";
 import { GradientPicker } from "./GradientPicker";
 import { useEffect } from "react";
 
+// Generate a random color (with high saturation)
+const generateRandomColor = () => {
+  const hue = Math.floor(Math.random() * 360);
+  const saturation = 60 + Math.floor(Math.random() * 40); // 60-100%
+  const lightness = 50 + Math.floor(Math.random() * 20); // 50-70%
+  return `hsl(${hue}, ${saturation}%, ${lightness}%)`;
+};
+
 type Process = {
   arrival_time: number;
   burst_time: number;
@@ -45,17 +53,26 @@ export function ProcessForm({ addProcess, initialValues }: ProcessFormProps) {
     defaultValues: initialValues || {
       arrival_time: 0,
       burst_time: 1,
-      background: "#ffe83f",
+      background: generateRandomColor(),
     },
   });
 
   useEffect(() => {
-    if (initialValues) form.reset(initialValues);
+    if (initialValues) {
+      form.reset(initialValues);
+    } else {
+      // Generate new random color for new process
+      form.setValue("background", generateRandomColor());
+    }
   }, [initialValues, form]);
 
   const onSubmit = (data: z.infer<typeof ProcessSchema>) => {
     addProcess(data);
-    form.reset();
+    form.reset({
+      arrival_time: 0,
+      burst_time: 1,
+      background: generateRandomColor(),
+    });
   };
 
   return (


### PR DESCRIPTION
## Changes
Added `generateRandomColor()` function that generates vibrant HSL colors so that new processes automatically get a random color instead of default yellow (editing existing processes preserves their original color and users can still manually customize colors using the color picker).

Benefits:
- Improves visual distinction between processes automatically
- Better UX (no need to manually change color for each process)

Fixes #3