### PR TITLE
Fix FCFS waiting time always showing 0

### DIFF
--- a/components/SummaryTable.tsx
+++ b/components/SummaryTable.tsx
@@ -53,7 +53,7 @@ export function SummaryTable({
   });
 
   // If the algorithm is FCFS, calculate waiting and turnaround times after sorting by arrival time
-if (algorithm === "fCFS") {
+if (algorithm === "FCFS") {
   // Sort processes by arrival time for FCFS order, ignoring idle processes
   const sortedProcesses = [...calculatedProcesses].sort(
     (a, b) => a.arrival_time - b.arrival_time


### PR DESCRIPTION
Changed `algorithm === "fCFS"` to `algorithm === "FCFS"` in SummaryTable.tsx
This corrects a small typo in the algorithm comparison that caused FCFS waiting time calculations to be skipped. Fixes #16.